### PR TITLE
Update docker automated label on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker coredns
 
-[![Docker Automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/yorickps/coredns/builds/)
+[![Docker Automated build](https://img.shields.io/docker/automated/yorickps/coredns.svg)](https://hub.docker.com/r/yorickps/coredns/builds/)
 [![Build Status](https://travis-ci.org/yorickps/docker-coredns.svg?branch=master)](https://travis-ci.org/yorickps/docker-coredns)
 
 Docker image to run [CoreDNS](https://coredns.io/)


### PR DESCRIPTION
The existing label was using the wrong docker repository handler (`jrottenberg/ffmpeg` instead of `yorickps/coredns`).